### PR TITLE
Feature-2: Made chart more configurable

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 
 type: application
 
-version: 0.3.0
+version: 0.4.0
 
 appVersion: "latest"
 

--- a/templates/k8s_configmap.yaml
+++ b/templates/k8s_configmap.yaml
@@ -3,7 +3,5 @@ kind: ConfigMap
 metadata:
   name: olivetin-config
 data:
-  config.yaml: |
-    actions:
-      - title: "Hello world!"
-        shell: echo 'Hello World!'
+  config.yaml: |-
+{{ .Values.config | indent 4 }}

--- a/templates/k8s_deployment.yaml
+++ b/templates/k8s_deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
     name: olivetin
 spec:
-  replicas: {{ .Values.replicas }}
+  replicas: 1
   selector:
     matchLabels:
       app: olivetin

--- a/templates/k8s_deployment.yaml
+++ b/templates/k8s_deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
-metadata: 
+metadata:
     name: olivetin
-spec: 
-  replicas: 1
-  selector: 
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
     matchLabels:
       app: olivetin
   template:
@@ -12,11 +12,11 @@ spec:
       labels:
         app: olivetin
     spec:
-      containers: 
+      containers:
         - name: olivetin
           image: docker.io/jamesread/olivetin:latest
           ports:
-            - containerPort: 1337
+            - containerPort: {{ .Values.ingress.servicePort }}
           volumeMounts:
             - name: olivetin-config
               mountPath: "/config"
@@ -24,14 +24,13 @@ spec:
 
           livenessProbe:
             exec:
-              command: 
-                - curl 
-                - localhost:1337
+              command:
+                - curl
+                - localhost:{{ .Values.ingress.servicePort }}
             initialDelaySeconds: 5
             periodSeconds: 30
 
       volumes:
         - name: olivetin-config
-          configMap: 
+          configMap:
             name: olivetin-config
-

--- a/templates/k8s_ingress.yaml
+++ b/templates/k8s_ingress.yaml
@@ -1,14 +1,27 @@
 {{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
-metadata: 
+metadata:
   name: olivetin-ingress
 spec:
-  defaultBackend: 
-    service: 
+  defaultBackend:
+    service:
       name: olivetin
       port:
-        number: 1337
+        number: {{ .Values.ingress.servicePort }}
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ tpl . $ | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
   rules:
     - host: {{ .Values.ingress.host }}
       http:
@@ -19,5 +32,5 @@ spec:
               service:
                 name: olivetin
                 port:
-                  number: 1337
+                  number: {{ .Values.ingress.servicePort }}
 {{- end }}

--- a/templates/k8s_service.yaml
+++ b/templates/k8s_service.yaml
@@ -4,9 +4,9 @@ metadata:
   name: olivetin
 spec:
   ports:
-  - port: 1337
+  - port: {{ .Values.ingress.servicePort }}
     protocol: TCP
-    targetPort: 1337
+    targetPort: {{ .Values.ingress.servicePort }}
   selector:
     app: olivetin
   type: ClusterIP

--- a/values.yaml
+++ b/values.yaml
@@ -12,5 +12,3 @@ ingress:
   servicePort: 1337
 
 persistentVolume: true
-
-replicas: 1

--- a/values.yaml
+++ b/values.yaml
@@ -1,8 +1,16 @@
 ---
+config: |-
+  actions:
+    - title: "Hello world!"
+      shell: echo 'Hello World!'
+
+containerVersion: latest
+
 ingress:
   enabled: true
   host: olivetin.example.com
+  servicePort: 1337
 
-persisentVolume: true
+persistentVolume: true
 
-containerVersion: latest
+replicas: 1


### PR DESCRIPTION
I was interested in trying this Helm Chart out today. Along the way, I wanted to be able to configure it a little better. As a result, I made a number of values more configurable, most notably the `Ingress.yaml` TLS configuration and the `config.yaml` content.