### PR TITLE
bugfix: remove readOnly attribute from configmap volume

### DIFF
--- a/charts/olivetin/Chart.yaml
+++ b/charts/olivetin/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 
 type: application
 
-version: 3.0.1
+version: 3.0.2
 
 appVersion: "2025.6.6"
 

--- a/charts/olivetin/templates/deployment.yaml
+++ b/charts/olivetin/templates/deployment.yaml
@@ -64,7 +64,6 @@ spec:
         - name: config
           configMap:
             name: {{ include "olivetin.fullname" . }}-config
-            readOnly: true
       {{- with .Values.extraVolumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
readOnly attribute shouldn't be set explicitly, Kubenretes adds that parameter by itself. Setting this attribute explicitly causes OutOfSync status in ArgoCD